### PR TITLE
Replace conditional invoking with g_main_context_invoke

### DIFF
--- a/include/rxglib/run_loop.hpp
+++ b/include/rxglib/run_loop.hpp
@@ -16,7 +16,6 @@ class run_loop {
 
   run_loop(GMainLoop* loop, GMainContext* context)
       : rx_run_loop_{},
-        owner_tid_{std::this_thread::get_id()},
         loop_{loop},
         context_{context},
         timeout_source_{nullptr},
@@ -50,35 +49,25 @@ class run_loop {
 
  private:
   void on_earlier_wakeup(const clock_type::time_point& wakeup_point) {
-    if (owner_tid_ == std::this_thread::get_id()) {
-      if (wakeup_point < timeout_point_ || timeout_point_ < clock_type::now()) {
-        reset_timeout_source(wakeup_point);
-      }
-    } else {
-      auto queued_task = g_idle_source_new();
-      using Args = std::pair<run_loop*, clock_type::time_point>;
-      auto args = new Args{this, wakeup_point};
-      g_source_set_callback(queued_task,
-                            [](gpointer data) -> gboolean {
-                              auto args = static_cast<Args*>(data);
-                              auto this_ptr = args->first;
-                              const auto& wakeup_point = args->second;
-                              this_ptr->on_earlier_wakeup(wakeup_point);
-                              return false;
-                            },
-                            args,
-                            [](gpointer data) {
-                              auto args = static_cast<Args*>(data);
-                              delete args;
-                            });
-      g_source_attach(queued_task, context_);
-      g_source_unref(queued_task);
-    }
+    using Args = std::pair<run_loop*, clock_type::time_point>;
+    auto args = new Args{this, wakeup_point};
+    g_main_context_invoke(
+        context_,
+        [](gpointer data) -> gboolean {
+          auto args = static_cast<Args*>(data);
+          auto this_ptr = args->first;
+          const auto& wakeup_point = args->second;
+          if (wakeup_point < this_ptr->timeout_point_ ||
+              this_ptr->timeout_point_ < clock_type::now()) {
+            this_ptr->reset_timeout_source(wakeup_point);
+          }
+          delete args;
+          return false;
+        },
+        args);
   }
 
   void remove_glib_timeout_source() {
-    assert(owner_tid_ == std::this_thread::get_id());
-
     if (timeout_source_ != nullptr) {
       g_source_destroy(timeout_source_);
       g_source_unref(timeout_source_);
@@ -88,7 +77,7 @@ class run_loop {
   }
 
   void reset_timeout_source(const clock_type::time_point& wakeup_point) {
-    assert(owner_tid_ == std::this_thread::get_id());
+    assert(g_main_context_is_owner(context_) == TRUE);
 
     // Discard last timeout source.
     remove_glib_timeout_source();
@@ -99,21 +88,22 @@ class run_loop {
                  std::chrono::milliseconds::zero())
             .count());
     auto new_timeout_source = g_timeout_source_new(millisec);
-    g_source_set_callback(new_timeout_source,
-                          [](gpointer data) -> gboolean {
-                            // Dispatch scheduled rx events.
-                            auto this_ptr = static_cast<run_loop*>(data);
-                            this_ptr->on_rx_event_scheduled();
-                            return false;
-                          },
-                          this, nullptr);
+    g_source_set_callback(
+        new_timeout_source,
+        [](gpointer data) -> gboolean {
+          // Dispatch scheduled rx events.
+          auto this_ptr = static_cast<run_loop*>(data);
+          this_ptr->on_rx_event_scheduled();
+          return false;
+        },
+        this, nullptr);
     g_source_attach(new_timeout_source, context_);
     timeout_source_ = new_timeout_source;
     timeout_point_ = wakeup_point;
   }
 
   void on_rx_event_scheduled() {
-    assert(owner_tid_ == std::this_thread::get_id());
+    assert(g_main_context_is_owner(context_) == TRUE);
 
     while (!rx_run_loop_.empty() &&
            rx_run_loop_.peek().when < clock_type::now()) {
@@ -127,7 +117,6 @@ class run_loop {
   }
 
   rxcpp::schedulers::run_loop rx_run_loop_;
-  std::thread::id owner_tid_;
 
   GMainLoop* loop_;
   GMainContext* context_;


### PR DESCRIPTION
- Replace condition invoking in on_earlier_wakeup function with
  g_main_context_invoke to make reschedule task invoked on given
  context.
- Replace thread id checking statement with g_main_context_is_owner
  function.